### PR TITLE
Don't include rfm_edf_ecomanager.cpp from sketch

### DIFF
--- a/rfm_edf_ecomanager.ino
+++ b/rfm_edf_ecomanager.ino
@@ -5,6 +5,3 @@
 #include <new_fix.h>
 #include <utilsconsts.h>
 #include <Logger.h>
-
-/* Include the actual main function for the code: */
-#include "rfm_edf_ecomanager.cpp"


### PR DESCRIPTION
This include causes compilation to fail with multiple definition errors. All source files in the sketch folder will be compiled so there's no need to include them from the .ino file.

Fixes https://github.com/JackKelly/rfm_edf_ecomanager/issues/59

CC: @peterg10